### PR TITLE
feat: 비밀번호 재설정 링크 전송

### DIFF
--- a/components/auth/FindPasswordModal.tsx
+++ b/components/auth/FindPasswordModal.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useRef, useState } from 'react';
 import Button from './Button';
 import FormField from './FormField';
+import { auth } from '@/lib/firebase';
+import { sendPasswordResetEmail } from 'firebase/auth';
 
 type FindPasswordModalProps = {
   onClose: () => void;
@@ -28,6 +30,13 @@ const FindPasswordModal = ({ onClose }: FindPasswordModalProps) => {
     }
 
     // 이메일 요청 로직
+    sendPasswordResetEmail(auth, email)
+      .then(() => {
+        alert('이메일이 발송되었습니다.');
+      })
+      .catch((error) => {
+        alert('에러 발생: ' + error.message);
+      });
   };
 
   // esc로 모달을 닫을 수 있는 기능


### PR DESCRIPTION
## 1) 작업한 이슈번호
#1 

## 2) 변경 요약 (What & Why)

- **무엇을** 변경했는지: 비밀번호 재설정 모달에서 이메일 입력하면 해당 메일로 비밀번호 재설정 링크 전송
- **왜** 변경했는지(문제/목표):

## 3) 스크린샷/동영상 (UI 변경 시)

> 전/후 비교, 반응형(모바일/데스크톱) 캡쳐

- Before:
- After:

## 4) 상세 변경사항

- 라우팅/페이지:
- 컴포넌트: FindPasswordModal.tsx
- 상태관리:
- API 호출:
- 스타일:
- 기타:

## 5) 참고사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 비밀번호 찾기 모달에서 비밀번호 재설정 이메일 전송 기능이 추가되었습니다. 사용자가 이메일 주소를 제출하면 비밀번호 재설정 이메일이 발송되며, 성공 및 오류 상황에 대한 알림이 표시됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->